### PR TITLE
Migrate to sqlcipher-android library

### DIFF
--- a/hammock-sync-datastore-android-encryption/build.gradle
+++ b/hammock-sync-datastore-android-encryption/build.gradle
@@ -56,14 +56,14 @@ configurations.all {
 
 
 dependencies {
-    implementation "net.zetetic:android-database-sqlcipher:4.5.3"
+    implementation "net.zetetic:sqlcipher-android:4.6.0@aar"
     implementation "androidx.sqlite:sqlite:2.3.0"
     implementation project(':hammock-sync-datastore-android')
     implementation project(':hammock-sync-datastore-core')
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.14.2'
     implementation group: 'commons-codec', name: 'commons-codec', version:'1.15'
-    implementation group: 'commons-io', name: 'commons-io', version:'2.11.0'
+    implementation group: 'commons-io', name: 'commons-io', version:'2.16.1'
 
     // for unit tests
     androidTestImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/hammock-sync-datastore-android-encryption/src/androidTest/java/org/hammock/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/hammock-sync-datastore-android-encryption/src/androidTest/java/org/hammock/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -41,7 +41,7 @@ import org.hammock.sync.query.QueryException;
 import org.hammock.sync.query.QueryResult;
 import org.hammock.sync.util.TestUtilsEncrypt;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
@@ -83,7 +83,8 @@ public class EndToEndEncryptionTest {
 
     static {
         // Load SQLCipher libraries
-        SQLiteDatabase.loadLibs(ProviderTestUtil.getContext());
+        System.loadLibrary("sqlcipher");
+        //SQLiteDatabase.loadLibs(ProviderTestUtil.getContext());
     }
 
     @Parameterized.Parameters(name = "{index}: encryption={0}")

--- a/hammock-sync-datastore-android-encryption/src/main/java/org/hammock/sync/internal/sqlite/android/AndroidSQLCipherSQLite.java
+++ b/hammock-sync-datastore-android-encryption/src/main/java/org/hammock/sync/internal/sqlite/android/AndroidSQLCipherSQLite.java
@@ -26,6 +26,8 @@ package org.hammock.sync.internal.sqlite.android;
  * Created by estebanmlaver.
  */
 
+import android.database.SQLException;
+
 import org.hammock.sync.internal.android.ContentValues;
 import org.hammock.sync.documentstore.encryption.KeyProvider;
 import org.hammock.sync.internal.documentstore.encryption.KeyUtils;
@@ -33,9 +35,8 @@ import org.hammock.sync.internal.sqlite.Cursor;
 import org.hammock.sync.internal.sqlite.SQLDatabase;
 import org.hammock.sync.internal.util.Misc;
 
-import net.sqlcipher.database.SQLiteConstraintException;
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteException;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+
 
 import java.io.File;
 
@@ -52,9 +53,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
     public static AndroidSQLCipherSQLite open(File path, KeyProvider provider) {
 
         //Call SQLCipher-based method for opening database, or creating if database not found
-        SQLiteDatabase db = SQLiteDatabase.openOrCreateDatabase(path,
-                KeyUtils.sqlCipherKeyForKeyProvider(provider), null);
-
+        SQLiteDatabase db = SQLiteDatabase.openOrCreateDatabase(path.toString(),KeyUtils.sqlCipherKeyForKeyProvider(provider),null,null);
         return new AndroidSQLCipherSQLite(db);
     }
 
@@ -66,7 +65,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
     public void compactDatabase() {
         try {
             database.execSQL("VACUUM");
-        } catch (net.sqlcipher.SQLException e) {
+        } catch (SQLException e) {
             String error = "Fatal error running 'VACUUM', the database is probably malfunctioning.";
             throw new IllegalStateException(error);
         }
@@ -110,7 +109,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
         Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         try {
             this.database.execSQL(sql);
-        } catch (net.sqlcipher.SQLException e) {
+        } catch (SQLException e) {
             throw new java.sql.SQLException(e);
         }
     }
@@ -124,7 +123,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
         Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         try {
             this.database.execSQL(sql, bindArgs);
-        } catch (net.sqlcipher.SQLException e) {
+        } catch (SQLException e) {
             throw new java.sql.SQLException(e);
         }
     }
@@ -143,7 +142,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
     public Cursor rawQuery(String sql, String[] values) throws java.sql.SQLException {
         try {
             return new AndroidSQLiteCursor(this.database.rawQuery(sql, values));
-        } catch (SQLiteException e) {
+        } catch (SQLException e) {
             throw new java.sql.SQLException(e);
         }
     }
@@ -165,7 +164,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
         try {
             return this.database.insertWithOnConflict("\""+table+"\"", null,
                     createAndroidContentValues(initialValues), conflictAlgorithm);
-        } catch (SQLiteConstraintException sqlce){
+        } catch (Exception sqlce){
             return -1;
         }
     }


### PR DESCRIPTION
# Migrate from deprecated android-database-sqlcipher to sqlcipher-android

## Description

This PR migrates the project's database encryption implementation from the deprecated `android-database-sqlcipher` library to the currently maintained `sqlcipher-android` library.

The `android-database-sqlcipher` library is no longer actively maintained, and the project maintainers recommend migrating to the `sqlcipher-android` library, which is the actively maintained fork of the original SQLCipher project.

## Changes

Replaced all usages of `android-database-sqlcipher` with `sqlcipher-android` in the project.
Verified that the database encryption functionality continues to work as expected after the migration.

## Benefits

- Ensures the project is using an actively maintained library for database encryption.
- Reduces the risk of encountering issues or vulnerabilities due to the deprecated library.
