### PR TITLE
Fix Android Encryption dependencies exposure 

### DIFF
--- a/datastore-android-encryption/README.md
+++ b/datastore-android-encryption/README.md
@@ -1,0 +1,38 @@
+# Hammock Sync Encrypted Datastore for Android
+This projects contains the implementation of the Encrypted Datastore for Android. The SQLite 
+encryption is supported in the [SQLChipher][SQLCipher] library for Android which requires including its
+[BSD-style license][BSD-style license] and copyright in your application and documentation. Therefore,
+if you use document store encryption in your application, please follow the instructions 
+mentioned [here](https://www.zetetic.net/sqlcipher/open-source/).
+
+[SQLCipher]: https://www.zetetic.net/sqlcipher/
+[BSD-style license]:https://www.zetetic.net/sqlcipher/license/
+
+# Licenses
+This software relays on Zetetic's SQLCipher library, distributed under the following licensing terms
+and copyrights.
+
+Copyright (c) 2008-2023, ZETETIC LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of the ZETETIC LLC nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ZETETIC LLC BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/datastore-android-encryption/build.gradle
+++ b/datastore-android-encryption/build.gradle
@@ -58,8 +58,8 @@ configurations.all {
 dependencies {
     implementation "net.zetetic:sqlcipher-android:4.6.0@aar"
     implementation "androidx.sqlite:sqlite:2.3.0"
-    implementation project(':datastore-android')
-    implementation project(':datastore-core')
+    api project(':datastore-android')
+    api project(':datastore-core')
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.14.2'
     implementation group: 'commons-codec', name: 'commons-codec', version:'1.15'
@@ -105,7 +105,7 @@ publishing {
                 description = 'Android encripted storage implemenation for the Hammock Sync Library'
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
+                        name = 'Apache-2.0'
                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }

--- a/datastore-android-encryption/src/main/java/org/hammock/sync/datastore/encryption/KeyStorage.java
+++ b/datastore-android-encryption/src/main/java/org/hammock/sync/datastore/encryption/KeyStorage.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 class KeyStorage {
     private static final Logger LOGGER = Logger.getLogger(KeyStorage.class.getCanonicalName());
     private static final String CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE =
-            "com.cloudant.sync.CDTEncryptionKeychainStorage.keychain.service";
+            "com.hammock.sync.CDTEncryptionKeychainStorage.keychain.service";
 
     private static final String PREF_NAME_DPK = "dpk"; //$NON-NLS-1$
 

--- a/datastore-android/build.gradle
+++ b/datastore-android/build.gradle
@@ -104,7 +104,7 @@ publishing {
                 description = 'Android implemenation for the Hammock Sync Library'
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
+                        name = 'Apache-2.0'
                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }

--- a/datastore-core/build.gradle
+++ b/datastore-core/build.gradle
@@ -118,7 +118,7 @@ publishing {
                 description = 'Main logic implemenation for the Hammock Sync Library'
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
+                        name = 'Apache-2.0'
                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }

--- a/datastore-javase/build.gradle
+++ b/datastore-javase/build.gradle
@@ -69,7 +69,7 @@ publishing {
                 description = 'JavaSE Support for Hammock Sync Library'
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
+                        name = 'Apache-2.0'
                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }

--- a/doc/encryption.md
+++ b/doc/encryption.md
@@ -1,0 +1,127 @@
+# DocumentStore encryption
+
+Android’s document store now supports encryption of all data inside your database 
+using 256-bit AES: JSON documents, Query indexes and attachments.
+
+JSON documents and Query indexes are stored in SQLite databases. We use
+SQLCipher to encrypt the data in those databases. Attachment data is 
+stored as binary blobs on the filesystem. We use the Android JCE implementation
+for this, using 256-bit AES in CBC mode. Each distinct file blob gets its
+own IV, stored with the file on disk.
+
+## Using Encryption in your Application
+
+If you plan to use encryption, first you need to include the Hammock Sync Datastore Encryption 
+artifact in your project dependencies.
+
+```gradle
+   implementation 'org.hammock.sync:datastore-android.encryption:<version>'
+```
+
+Our implementation uses [SQLCipher Community Edition][1] as encryption support for SQLite databases 
+in Android. Hammock Sync uses the AAR distribution that contains the `.jar` and `.so` binary files required 
+by the encryption library.
+
+[1]: https://www.zetetic.net/sqlcipher/open-source/
+
+Once you've included the proper Hammock Sync artifact in your app's build, you need to perform some 
+set up in code:
+
+1.	Load SQLCipher library.  This line needs to be done before any database calls:
+    
+    ```java
+        System.loadLibrary("sqlcipher");
+    ```
+
+2.	With encryption, two parameters are required in the `getInstance` call: the 
+    application storage path and a `KeyProvider` object.  The `KeyProvider` interface 
+    can be instantiated with the `SimpleKeyProvider` class, which just provides a
+    developer or user set encryption key.  Create a new SimpleKeyProvider 
+    by providing a 256-bit key as a `byte` array in the constructor. For example:
+    
+    ```java
+    // Security risk here: hard-coded key.
+    // We recommend using java.util.SecureRandom to generate your key, then
+    // storing securely or retrieving it from elsewhere. 
+    // Or use AndroidKeyProvider, which does this for you.
+    byte[] key = "testAKeyPasswordtestAKeyPassword".getBytes();  
+    KeyProvider keyProvider = new SimpleKeyProvider(key); 
+
+    File path = getApplicationContext().getDir("documentstores", MODE_PRIVATE);
+
+    DocumentStore ds = DocumentStore.getInstance(new File(path, "my_documentstore"), keyProvider);
+    ```
+    
+    Note: The key _must_ be 32 bytes (256-bit key). `"testAKeyPasswordtestAKeyPassword"`
+    happens to meet this requirement when `getBytes()` is called, which makes this
+    example more readable.
+    
+    See the next section for a secure key provider, which generates and protects keys
+    for you.
+
+## Secure Key Generation and Storage using AndroidKeyProvider
+
+The SimpleKeyProvider does not provide proper management and storage of the key.  
+If this is required, use the `AndroidKeyProvider`. This class handles 
+generating a strong encryption key protected using the provided password. The
+key data is encrytped and saved into the application's `SharedPreferences`. The 
+constructor requires the Android context, a user-provided password, and an 
+identifier to access the saved data in SharedPreferences.
+
+Example:
+
+```java
+KeyProvider keyProvider = new AndroidKeyProvider(context, 
+        "ASecretPassword", "AnIdentifier");
+DocumentStore ds = DocumentStore.getInstance(new File(path, "my_documentstore"), keyProvider);
+```
+
+One example of an identifier might be if multiple users share the same
+device, the identifier can be used on a per user basis to store a key
+to their individual database.
+
+Right now, a different key is stored under each identifier, so one cannot
+use identifiers to allow different users access to the same encrypted
+database -- each user would get a different encryption key, and would
+not be able to decrypt the database. For this use case, currently 
+a custom implementation of `KeyProvider` is required.
+
+## Full code sample:
+
+```java
+protected void onCreate(Bundle savedInstanceState) {
+ 
+    super.onCreate(savedInstanceState);
+ 
+    SQLiteDatabase.loadLibs(this);
+ 
+    // Get a DocumentStore instance with encryption using 
+    // application internal storage path and a key
+    File path = getApplicationContext().getDir("documentstores", MODE_PRIVATE);
+    KeyProvider keyProvider = 
+            new SimpleKeyProvider("testAKeyPasswordtestAKeyPassword".getBytes());
+ 
+    DocumentStore ds = null;
+    try {
+        ds = DocumentStore.getInstance(new File(path, "my_documentstore"), keyProvider);
+    } catch (DocumentStoreNotOpenedException e) {
+        e.printStackTrace();
+    }
+        
+    // ...
+````
+
+## Licence
+
+We use [JCE][JCE] library to encrypt the attachments before
+saving to disk. There should be no licencing concerns for using JCE.
+
+Databases are automatically encrypted with
+[SQLCipher][SQLCipher]. SQLCipher requires including its
+[BSD-style license][BSD-style license] and copyright in your application and
+documentation. Therefore, if you use document store encryption in your application, 
+please follow the instructions mentioned [here](https://www.zetetic.net/sqlcipher/open-source/).
+
+[SQLCipher]: https://www.zetetic.net/sqlcipher/
+[JCE]: http://developer.android.com/reference/javax/crypto/package-summary.html
+[BSD-style license]:https://www.zetetic.net/sqlcipher/license/


### PR DESCRIPTION
This PR fixes how the Hammock Sync dependencies are exposed for usage by the final application. It also includes the review of the encryption related documentation. 