### PR TITLE
Bump CouchDB version to 3.4.1

### DIFF
--- a/.github/workflows/hammock-sync-build-push.yml
+++ b/.github/workflows/hammock-sync-build-push.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        couchdb: [3.3.3]
+        couchdb: [3.4.1]
       fail-fast: true
       max-parallel: 1
     steps:

--- a/.github/workflows/hammock-sync-build.yml
+++ b/.github/workflows/hammock-sync-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        couchdb: [3.3.3, 2.3.1, 1.7.2]
+        couchdb: [3.4.1, 2.3.1, 1.7.2]
       fail-fast: true
       max-parallel: 1
     steps:


### PR DESCRIPTION
This PR bumps CouchDB to version 3.4.1 as test environment.