### PR TITLE
chore: Use CouchDB 3.4.3 in CI workflows

### DIFF
--- a/.github/workflows/hammock-sync-build-push.yml
+++ b/.github/workflows/hammock-sync-build-push.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        couchdb: [3.4.1]
+        couchdb: [3.4.3]
       fail-fast: true
       max-parallel: 1
     steps:

--- a/.github/workflows/hammock-sync-build.yml
+++ b/.github/workflows/hammock-sync-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        couchdb: [3.4.1, 2.3.1, 1.7.2]
+        couchdb: [3.4.3, 2.3.1, 1.7.2]
       fail-fast: true
       max-parallel: 1
     steps:


### PR DESCRIPTION
This pull request updates the CouchDB version used in the CI workflows to ensure compatibility and leverage the latest improvements and fixes. The most important changes include updating the CouchDB version in two workflow files.

CI Workflow updates:

* [`.github/workflows/hammock-sync-build-push.yml`](diffhunk://#diff-251be4d13165728cb4b6cd29ccad396719faaa1b43bff61f87bcc4ca3bfcc488L16-R16): Updated CouchDB version from `3.4.1` to `3.4.3`.
* [`.github/workflows/hammock-sync-build.yml`](diffhunk://#diff-eddd13d7ee1352909b009aa0727e6f7b5e10eb5d168000163a76864096e5e299L17-R17): Updated CouchDB version from `3.4.1` to `3.4.3`.