### PR TITLE
ci: use 3.5.0 as testing release, and remove test over 1.7.0

### DIFF
--- a/.github/workflows/hammock-sync-build-push.yml
+++ b/.github/workflows/hammock-sync-build-push.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        couchdb: [3.4.3]
+        couchdb: [3.5.0]
       fail-fast: true
       max-parallel: 1
     steps:

--- a/.github/workflows/hammock-sync-build.yml
+++ b/.github/workflows/hammock-sync-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        couchdb: [3.4.3, 2.3.1, 1.7.2]
+        couchdb: [3.5.0, 3.4.3, 2.3.1]
       fail-fast: true
       max-parallel: 1
     steps:


### PR DESCRIPTION
This pull request updates the CouchDB versions used in the GitHub Actions workflows for building, testing, and pushing the project. The changes ensure that the workflows are aligned with the latest CouchDB version.

Workflow updates:

* [`.github/workflows/hammock-sync-build-push.yml`](diffhunk://#diff-251be4d13165728cb4b6cd29ccad396719faaa1b43bff61f87bcc4ca3bfcc488L16-R16): Updated the CouchDB version in the matrix to use `3.5.0` instead of `3.4.3`.
* [`.github/workflows/hammock-sync-build.yml`](diffhunk://#diff-eddd13d7ee1352909b009aa0727e6f7b5e10eb5d168000163a76864096e5e299L17-R17): Added `3.5.0` as the latest CouchDB version in the matrix, while retaining `3.4.3`, `2.3.1`, and `1.7.2`.